### PR TITLE
1.3.1

### DIFF
--- a/1.6/Base/Defs/RecipeDefs/SNS_Recipe_Fabricator.xml
+++ b/1.6/Base/Defs/RecipeDefs/SNS_Recipe_Fabricator.xml
@@ -272,6 +272,24 @@
 			</li>
 		</ingredients>
 	</RecipeDef>
+	<RecipeDef MayRequire="zal.morearchotechgarbage" ParentName="SNS_Constructor_Item">
+		<defName>SNS_Production_Fabricator_Archotech_Fragment</defName>
+		<label>Archotech Fragment production</label>
+		<description>Pattern five fragments of Archotech technology.</description>
+		<products>
+			<ArchotechScrap>10</ArchotechScrap>
+		</products>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>SNS_CosmicMatter</li>
+					</thingDefs>
+				</filter>
+				<count>200</count>
+			</li>
+		</ingredients>
+	</RecipeDef>
 	<RecipeDef ParentName="SNS_Constructor_Item">
 		<defName>SNS_Production_Fabricator_Penoxycyline</defName>
 		<label>Pattern Penoxycyline</label>

--- a/1.6/Base/Defs/RecipeDefs/SNS_Recipe_PinnacleFabricator.xml
+++ b/1.6/Base/Defs/RecipeDefs/SNS_Recipe_PinnacleFabricator.xml
@@ -385,7 +385,7 @@
 	<RecipeDef MayRequire="zal.morearchotechgarbage" ParentName="SNS_PinnacleFabricator_Item">
 		<defName>SNS_Production_PinnacleFabricator_ArchotechFragment</defName>
 		<label>Draw Archotech Fragments</label>
-		<description>Draw fragments of Archotechnolofy directly from the Eternla plane.</description>
+		<description>Draw fragments of Archotechnology directly from the Eternal plane.</description>
 		<products>
 			<ArchotechScrap>75</ArchotechScrap>
 		</products>

--- a/1.6/Base/Defs/RecipeDefs/SNS_Recipe_PinnacleFabricator.xml
+++ b/1.6/Base/Defs/RecipeDefs/SNS_Recipe_PinnacleFabricator.xml
@@ -382,4 +382,12 @@
 			<SNS_Eternium>75</SNS_Eternium>
 		</products>
 	</RecipeDef>
+	<RecipeDef MayRequire="zal.morearchotechgarbage" ParentName="SNS_PinnacleFabricator_Item">
+		<defName>SNS_Production_PinnacleFabricator_ArchotechFragment</defName>
+		<label>Draw Archotech Fragments</label>
+		<description>Draw fragments of Archotechnolofy directly from the Eternla plane.</description>
+		<products>
+			<ArchotechScrap>75</ArchotechScrap>
+		</products>
+	</RecipeDef>
 </Defs>

--- a/1.6/Base/Defs/ResearchProjectDefs/SNS_ResearchProjects.xml
+++ b/1.6/Base/Defs/ResearchProjectDefs/SNS_ResearchProjects.xml
@@ -55,8 +55,8 @@
 
 	<ResearchProjectDef ParentName="SNS_Research_Base_GenI">
 		<defName>SNS_Research_I</defName>
-		<label>Stellar Steel</label>
-		<description>It is time that we harnessed the power of Cosmic Matter on this planet. Through the investigation of Cosmic Matter's influence and reaction to various materials, we could hopefully create an alloy strong enough to house the endless power of Cosmic Matter.</description>
+		<label>Starsteel Production</label>
+		<description>Cosmic Matter exists everywhere, and its power is just at our fingertips. Through the investigation of Cosmic Matter's influence and reaction to various materials, we could hopefully create an alloy strong enough to house its endless power.</description>
 		<baseCost>15000</baseCost>
 		<techLevel>Ultra</techLevel>
 		<prerequisites>
@@ -82,7 +82,7 @@
 	<ResearchProjectDef ParentName="SNS_Research_Base_GenI">
 		<defName>SNS_Research_II_bionics</defName>
 		<label>Stellar Bionics</label>
-		<description>The bionic limbs of today suffer from the truth that they have limits. There are just things bionics cannot achieve alone, even the grand Archotech set of bionics often cannot rise to the occasion.\n\nSo, we will turn to Starsteel to make limbs both precise and tough, able to last a soldier and sate a mechanic.</description>
+		<description>Bionics of today are incredibly advanced. Yet, they are limited by the materials of the time. Even the mighty Archotechs couldn't break through this limit. Yet, Starsteel is a material with incredible potential, maybe allowing us to surpass those limits.\n\nSo, we will turn to Starsteel to make limbs both precise and tough, able to last a soldier and sate a mechanic.</description>
 		<baseCost>15000</baseCost>
 		<techLevel>Ultra</techLevel>
 		<prerequisites>
@@ -121,7 +121,7 @@
 	<ResearchProjectDef ParentName="SNS_Research_Base_GenI">
 		<defName>SNS_Research_II_armor</defName>
 		<label>Stellar Armors</label>
-		<description>Starsteel can withstand intense pressures and take an extreme amount of damage. It would logically make the perfect armor, able to withstand all forces with ease.</description>
+		<description>The ability of Starsteel to absorb shock and disperse it is incredible. It would logically make the perfect armor, able to withstand all forces with ease.</description>
 		<baseCost>15000</baseCost>
 		<techLevel>Ultra</techLevel>
 		<prerequisites>
@@ -147,7 +147,7 @@
 	<ResearchProjectDef ParentName="SNS_Research_Base_GenI">
 		<defName>SNS_Research_II_hydroponics</defName>
 		<label>Cosmic Hydroponics</label>
-		<description>Hydroponics Basins can be made significantly more efficient with the introduction of a more intensive nutrient bath with the light sprinking of Starsteel, nearly tripling the effectiveness of Hydroponics-based technology.</description>
+		<description>By using Starsteel as a conduit for Cosmic Matter, we can slowly diffuse it within hydroponics basins, using it as a nutrient that will nearly triple the efficiency of our hydroponics.</description>
 		<baseCost>15000</baseCost>
 		<techLevel>Ultra</techLevel>
 		<prerequisites>
@@ -173,7 +173,7 @@
 	<ResearchProjectDef ParentName="SNS_Research_Base_GenI">
 		<defName>SNS_Research_II_food</defName>
 		<label>Perfected Food Preparation</label>
-		<description>To reach for the stars we needed both full rockets and full stomachs. Let us ensure we can do both for the long journey ahead of us!\n\nFood is cooked just like any other meals, on the electric/fueled stove.</description>
+		<description>To reach for the stars we needed both full rockets and full stomachs. Let us ensure we can do both for the long journey ahead of us!</description>
 		<baseCost>15000</baseCost>
 		<techLevel>Ultra</techLevel>
 		<prerequisites>
@@ -186,7 +186,7 @@
 	<ResearchProjectDef ParentName="SNS_Research_Base_GenI">
 		<defName>SNS_Research_II_drugs</defName>
 		<label>Advanced Drug Production</label>
-		<description>Recreational and functional drugs of today are rather flawed, most having various side-effects and/or long-term damage that cause great risk--especially for those who lack self-control. While we cannot re-create them perfectly, we can at least try to make something better.\n\nAnything unlocked by this technology are either made in a Stove or the Drug Lab.</description>
+		<description>Recreational and functional drugs of today are rather flawed, most having various side-effects and/or long-term damage that cause great risk--especially for those who lack self-control. While we cannot re-create them perfectly, we can at least try to make something better.</description>
 		<baseCost>15000</baseCost>
 		<techLevel>Ultra</techLevel>
 		<prerequisites>
@@ -214,7 +214,7 @@
 	<ResearchProjectDef ParentName="SNS_Research_Base_GenI">
 		<defName>SNS_Research_II_bridge</defName>
 		<label>Cosmic Theory</label>
-		<description>We must reach higher, and grasp beyond even the Stars themselves. We must sieze the very fabric of the universe to reach our final destination. We must achieve purity, we must achieve perfection, we must achieve eternity. We must draw from the very source, find the key to our desires of a cosmic age.</description>
+		<description>We must reach higher, and grasp beyond even the Stars themselves. We must seize the very fabric of the universe to reach our final destination. We must achieve purity, we must achieve perfection, we must achieve eternity. We must draw from the very source, find the key to our desires of a cosmic age.</description>
 		<baseCost>17500</baseCost>
 		<techLevel>Ultra</techLevel>
 		<prerequisites>
@@ -237,7 +237,7 @@
 	<ResearchProjectDef ParentName="SNS_Research_Base_GenII">
 		<defName>SNS_Research_III_base</defName>
 		<label>The Second Generation</label>
-		<description>Meeting the absolute zenith of human technology, we achieve the Second Generation of the Ancient's arcane technologies.\n\nThis technology unlocks the Cosmic Manipulator, which allows you to either make Cosmic Matter or the legendary Cosmic Alloy.</description>
+		<description>Meeting the absolute zenith of human technology, we achieve the Second Generation of the Ancient's arcane technologies.\n\nThis technology unlocks the Cosmic Manipulator, which allows you to either make Cosmic Matter or the legendary Cosmic Alloy, a new alloy allowing us to use Cosmic Matter with a much greater efficiency.</description>
 		<baseCost>25000</baseCost>
 		<techLevel>Archotech</techLevel>
 		<prerequisites>

--- a/1.6/Base/Defs/ThingDefs_Combat/SNS_Armor_Gen3.xml
+++ b/1.6/Base/Defs/ThingDefs_Combat/SNS_Armor_Gen3.xml
@@ -476,7 +476,7 @@
     </apparel>
   </ThingDef>
   
-  <ThingDef Name="ApparelStableMatterPowerArmorPsycastHelmetBase" ParentName="ArmorHelmetMakeableBase" Abstract="True">
+  <ThingDef MayRequire="Ludeon.RimWorld.Royalty" Name="ApparelStableMatterPowerArmorPsycastHelmetBase" ParentName="ArmorHelmetMakeableBase" Abstract="True">
     <techLevel>Archotech</techLevel>
 	<useHitPoints>false</useHitPoints>
     <recipeMaker>
@@ -537,13 +537,13 @@
     </apparel>
   </ThingDef>
 	
-	<ThingDef ParentName="ApparelStableMatterPowerArmorPsycastHelmetBase">
+	<ThingDef MayRequire="Ludeon.RimWorld.Royalty" ParentName="ApparelStableMatterPowerArmorPsycastHelmetBase">
     <defName>SNS_Apparel_StableMatterPowerArmorHelmetPsycast</defName>
     <label>CHARON Psycaster Helmet</label>
     <description>A pressure-sealed Abyssal Power Armor Helmet fueled by Eternium. Incredibly lightweight, tough, protective, and comfortable, this power-armor helmet is far superior to that of its predecessors in every way imaginable.\n\nThis helmet was designed with specialization in mind. It ditches all the regular enhancements of the CHARON armor, apart from its speed, which remains slower, all of these enhancements have been replaced by a powerful mental-enhancing array, allowing the wearer to wield psychic powers much better than any unaugmented psycaster.</description>
   </ThingDef>
   
-  <ThingDef ParentName="ArmorMachineableBase">
+  <ThingDef MayRequire="Ludeon.RimWorld.Royalty" ParentName="ArmorMachineableBase">
     <defName>SNS_Apparel_StableMatterPowerArmorPsycast</defName>
     <label>CHARON Psycaster Armor</label>
    <description>A suit of Abyssal Power Armor fueled by Eternium. Incredibly lightweight, tough, protective, and comfortable, this suit of power armor is far superior to that of its previous generation in every way imaginable.\n\nThis armor was designed specifically for psycasters. All enhancements but the speed have been removed to be replaced by a combination of a mental stabilizing array and powerful psy-enhancers, allowing the wearer to remain calm,while manipulating the powers of the Arcane.</description>
@@ -631,7 +631,7 @@
     </apparel>
   </ThingDef>
   
-  <ThingDef Name="ApparelStableMatterPowerArmorMechanitorHelmetBase" ParentName="ArmorHelmetMakeableBase" Abstract="True">
+  <ThingDef MayRequire="Ludeon.RimWorld.Biotech" Name="ApparelStableMatterPowerArmorMechanitorHelmetBase" ParentName="ArmorHelmetMakeableBase" Abstract="True">
     <techLevel>Archotech</techLevel>
 	<useHitPoints>false</useHitPoints>
     <recipeMaker>
@@ -696,13 +696,13 @@
     </apparel>
   </ThingDef>
 	
-	<ThingDef ParentName="ApparelStableMatterPowerArmorMechanitorHelmetBase">
+	<ThingDef MayRequire="Ludeon.RimWorld.Biotech" ParentName="ApparelStableMatterPowerArmorMechanitorHelmetBase">
     <defName>SNS_Apparel_StableMatterPowerArmorMechanitorPsycast</defName>
     <label>CHARON Mechanitor Helmet</label>
     <description>A pressure-sealed Abyssal Power Armor Helmet fueled by Eternium. Incredibly lightweight, tough, protective, and comfortable, this power-armor helmet is far superior to that of its predecessors in every way imaginable.\n\nThis helmet was made specifically for Mechanitors. Nearly all of the upgrades of the regular CHARON armor have been replaced by a powerful mechlink calculation subcore, greatly enhancing the abilities of the user's Mechlink..</description>
   </ThingDef>
   
-  <ThingDef ParentName="ArmorMachineableBase">
+  <ThingDef MayRequire="Ludeon.RimWorld.Biotech" ParentName="ArmorMachineableBase">
     <defName>SNS_Apparel_StableMatterPowerArmorMechanitor</defName>
     <label>CHARON Mechanitor Armor</label>
    <description>A suit of Abyssal Power Armor fueled by Eternium. Incredibly lightweight, tough, protective, and comfortable, this suit of power armor is far superior to that of its previous generation in every way imaginable.\n\nThis armor was designed specifically for mechanitors. Its upgrades have been replaced by an integrated mechlink amplifier that allows the wearer to improve the mechanoids' work speed, alongside improving the mechlink's capabilities.</description>

--- a/1.6/Base/Defs/ThingDefs_Combat/SNS_Weapons_Melee_Gen1.xml
+++ b/1.6/Base/Defs/ThingDefs_Combat/SNS_Weapons_Melee_Gen1.xml
@@ -78,6 +78,7 @@
       <skillRequirements>
         <Crafting>12</Crafting>
       </skillRequirements>
+      <workSkill>Crafting</workSkill>
       <displayPriority>1000</displayPriority>
     </recipeMaker>
   </ThingDef>
@@ -159,6 +160,7 @@
       <skillRequirements>
         <Crafting>12</Crafting>
       </skillRequirements>
+      <workSkill>Crafting</workSkill>
       <displayPriority>1010</displayPriority>
     </recipeMaker>
   </ThingDef>
@@ -250,6 +252,7 @@
       <skillRequirements>
         <Crafting>12</Crafting>
       </skillRequirements>
+      <workSkill>Crafting</workSkill>
       <displayPriority>1020</displayPriority>
     </recipeMaker>
   </ThingDef>

--- a/1.6/Base/Defs/ThingDefs_Combat/SNS_Weapons_Melee_Gen2.xml
+++ b/1.6/Base/Defs/ThingDefs_Combat/SNS_Weapons_Melee_Gen2.xml
@@ -76,8 +76,9 @@
         <li>FabricationBench</li>
       </recipeUsers>
       <skillRequirements>
-        <Crafting>12</Crafting>
+        <Crafting>13</Crafting>
       </skillRequirements>
+      <workSkill>Crafting</workSkill>
       <displayPriority>1030</displayPriority>
     </recipeMaker>
   </ThingDef>
@@ -167,8 +168,9 @@
         <li>FabricationBench</li>
       </recipeUsers>
       <skillRequirements>
-        <Crafting>12</Crafting>
+        <Crafting>13</Crafting>
       </skillRequirements>
+      <workSkill>Crafting</workSkill>
       <displayPriority>1040</displayPriority>
     </recipeMaker>
   </ThingDef>
@@ -258,8 +260,9 @@
         <li>FabricationBench</li>
       </recipeUsers>
       <skillRequirements>
-        <Crafting>12</Crafting>
+        <Crafting>13</Crafting>
       </skillRequirements>
+      <workSkill>Crafting</workSkill>
       <displayPriority>1050</displayPriority>
     </recipeMaker>
   </ThingDef>

--- a/1.6/Base/Defs/ThingDefs_Combat/SNS_Weapons_Melee_Gen3.xml
+++ b/1.6/Base/Defs/ThingDefs_Combat/SNS_Weapons_Melee_Gen3.xml
@@ -98,6 +98,7 @@
       <skillRequirements>
         <Crafting>15</Crafting>
       </skillRequirements>
+      <workSkill>Crafting</workSkill>
       <displayPriority>1050</displayPriority>
     </recipeMaker>
   </ThingDef>
@@ -178,6 +179,7 @@
       <skillRequirements>
         <Crafting>15</Crafting>
       </skillRequirements>
+      <workSkill>Crafting</workSkill>
       <displayPriority>1050</displayPriority>
     </recipeMaker>
   </ThingDef>
@@ -268,6 +270,7 @@
       <skillRequirements>
         <Crafting>15</Crafting>
       </skillRequirements>
+      <workSkill>Crafting</workSkill>
       <displayPriority>1080</displayPriority>
     </recipeMaker>
   </ThingDef>

--- a/1.6/Base/Defs/ThingDefs_Items/SNS_Items_Resource.xml
+++ b/1.6/Base/Defs/ThingDefs_Items/SNS_Items_Resource.xml
@@ -576,7 +576,7 @@
 				<li>Fabric</li>
 				<li>Leathery</li>
 			</categories>
-			<color>(0,230,255)</color>
+			<color>(0,180,205)</color>
 			<appearance>Smooth</appearance>
 			<commonality>0.0</commonality>
 			<constructEffect>ConstructMetal</constructEffect> <!-- Item isn't intended to be used as a construction material, so I'll just leave it be here for now... -->

--- a/About/About.xml
+++ b/About/About.xml
@@ -24,6 +24,10 @@
     <li>V1024.EBFramework</li>
 	<li>CETeam.CombatExtended</li>
 	<li>vanillaexpanded.achievements</li>
+    <li>Ludeon.Rimworld.Biotech</li>
+    <li>Ludeon.Rimworld.Royalty</li>
+    <li>Ludeon.Rimworld.Anomaly</li>
+    <li>Ludeon.Rimworld.Odyssey</li>
   </loadAfter>
 <description><![CDATA[Welcome to Ambition of the Cosmic. This mod extends the late-game of RimWorld to the extreme, providing a massive time-sink for overwhelming power.
 


### PR DESCRIPTION
BUGFIXES
+Specialized CHARON armors requiring a DLC are no longer available if you do not have that DLC
It should prevent multiple errors.
+Added a skill to melee weapons (Crafting), to prevent an error on crafting.
+Finalized the complete removal of HugsLib
'Twas about time.

MOD INTERACTIONS
+You can now pattern and draw Archotech Fragments if you use More Archotech Garbage.

MISC.
+Dimmed the color of Eternium buildings.
The floor is next.
+Reworded multiple descriptions